### PR TITLE
Remove gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "gulp-uglify": "^3.0.0",
     "gulp-uncss": "^1.0.6",
     "gulp-useref": "^3.1.5",
-    "gulp-util": "^3.0.8",
     "run-sequence": "^2.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
- Gulp-util is now deprecated, so removing it as a dependency. It was not being used anyway.