### PR TITLE
Add support for Hound Sass linting

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+sass-lint:
+  enabled: true
+  config_file: .sass-lint.yml

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,111 @@
+options:
+  formatter: stylish
+
+files:
+  include: 'app/assets/stylesheets/**/*.s+(a|c)ss'
+
+rules:
+  # Extends
+  extends-before-mixins: 1
+  extends-before-declarations: 1
+  placeholder-in-extend: 0
+
+  # Mixins
+  mixins-before-declarations: 1
+
+  # Line Spacing
+  one-declaration-per-line: 1
+  empty-line-between-blocks: 1
+  single-line-per-selector: 1
+
+  # Disallows
+  no-attribute-selectors: 0
+  no-color-hex: 0
+  no-color-keywords: 1
+  no-color-literals: 1
+
+  no-combinators: 0
+  no-css-comments: 1
+  no-debug: 1
+  no-disallowed-properties: 0
+  no-duplicate-properties: 1
+  no-empty-rulesets: 1
+  no-extends: 0
+  no-ids: 0
+  no-important: 1
+  no-invalid-hex: 1
+  no-mergeable-selectors: 1
+  no-misspelled-properties: 1
+  no-qualifying-elements: 1
+  no-trailing-whitespace: 1
+  no-trailing-zero: 1
+  no-transition-all: 1
+  no-universal-selectors: 1
+  no-url-domains: 1
+  no-url-protocols: 1
+  no-vendor-prefixes: 1
+  no-warn: 1
+  property-units:
+    - 2
+    - global: ['rem', '%', 's', 'vw', 'vh', 'px', 'em']
+
+  # Nesting
+  declarations-before-nesting: 1
+  force-attribute-nesting: 1
+  force-element-nesting: 1
+  force-pseudo-nesting: 1
+
+  # Name Formats
+  class-name-format:
+    - 2
+    -
+      convention: hyphenatedbem
+      convention-explanation: 'Class must contain only lowercase letters, underscores and hyphens'
+
+  function-name-format: 1
+  id-name-format: 0
+  mixin-name-format: 1
+  placeholder-name-format: 1
+  variable-name-format: 1
+
+  # Style Guide
+  attribute-quotes: 1
+  bem-depth:
+    - 1
+    - max-depth: 3
+  border-zero: 1
+  brace-style: 1
+  clean-import-paths: 1
+  empty-args: 1
+  hex-length: 1
+  hex-notation: 1
+  indentation: 1
+  leading-zero: 1
+  max-line-length: 1
+  max-file-line-count: 0
+  nesting-depth:
+    - 1
+    -
+      max-depth: 3
+
+  property-sort-order: 0
+  pseudo-element: 1
+  quotes: 1
+  shorthand-values: 1
+  url-quotes: 1
+  variable-for-property: 1
+  zero-unit: 1
+
+  # Inner Spacing
+  space-after-comma: 1
+  space-before-colon: 1
+  space-after-colon: 1
+  space-before-brace: 1
+  space-before-bang: 1
+  space-after-bang: 1
+  space-between-parens: 1
+  space-around-operator: 1
+
+  # Final Items
+  trailing-semicolon: 1
+  final-newline: 1


### PR DESCRIPTION
This commit adds the required Hound files (`.hound.yml` and `.sass-lint.yml`) so
that Hound can lint the Sass files hosted on DadBot and ensure they are
following the convections set in `.sass-lint.yml`.