### PR TITLE
Remove `gulp-cache` package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,6 @@ var sass = require('gulp-sass')
 var browserSync = require('browser-sync').create()
 var runSequence = require('run-sequence')
 var imagemin = require('gulp-imagemin')
-var cache = require('gulp-cache')
 var del = require('del')
 var useref = require('gulp-useref')
 var uglify = require('gulp-uglify')
@@ -68,7 +67,7 @@ gulp.task('copy-fonts', function () {
 // Image compressor
 gulp.task('images', function () {
   return gulp.src('src/images/**/*.+(png|jpg|gif|svg)')
-    .pipe(cache(imagemin()))
+    .pipe(imagemin())
     .pipe(gulp.dest('dist/images'))
 })
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^6.1.0",
-    "gulp-cache": "^1.1.1",
     "gulp-concat": "^2.6.1",
     "gulp-concat-css": "^3.1.0",
     "gulp-if": "^2.0.2",


### PR DESCRIPTION
This commit removes support for the package `gulp-cache` as it is causing
build errors in local enviroments. This may be reinstated at another time
if image processing begins to cause a strain on compiling for
production.