### PR TITLE
Handle Netlify redirect for `/random-joke`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+# The following redirect is intended for use with most SPAs that handle
+# routing internally.
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/public/__redirects
+++ b/public/__redirects
@@ -1,1 +1,0 @@
-/index.html   200


### PR DESCRIPTION
This commit fixes an error in Netlify in which if a user arrived directly at the
`dadbot.com/random-joke` URL - they would be presented with a 404 error. This is
because there is not an index file located at /random-joke.

To prevent this from happening - we use a Netlify.toml file to configure our a
redirect back to the root URl and React Router handles the component that is
presented.